### PR TITLE
Fix constant requeue for get messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ queues, publishing messages to exchanges and reading messages from queues.
     * [Delete an exchange](#delete-an-exchange)
     * [Delete a queue](#delete-a-queue)
 * [Credits](#credits)
-    
+
 ## Example
 
 In the following example, a message `Hello!` is published and sent to an exchange called `my-exchange`. The RabbitMQ
@@ -375,7 +375,7 @@ $ buneary get binding localhost my-exchange my-queue
 **Syntax:**
 
 ```
-$ buneary publish <ADDRESS> <QUEUE NAME> [flags]
+$ buneary get messages <ADDRESS> <QUEUE NAME> [flags]
 ```
 
 **Arguments:**

--- a/buneary.go
+++ b/buneary.go
@@ -460,7 +460,6 @@ func (b *buneary) GetMessages(queue Queue, max int, requeue bool) ([]Message, er
 	// getMessagesRequestBody represents the HTTP request body for reading messages.
 	type getMessagesRequestBody struct {
 		Count    int    `json:"count"`
-		Requeue  bool   `json:"requeue"`
 		Encoding string `json:"encoding"`
 		Ackmode  string `json:"ackmode"`
 	}
@@ -476,11 +475,15 @@ func (b *buneary) GetMessages(queue Queue, max int, requeue bool) ([]Message, er
 		Payload      string                 `json:"payload"`
 	}
 
+	ackMode := "ack_requeue_false"
+	if requeue {
+		ackMode = "ack_requeue_true"
+	}
+
 	requestBody := getMessagesRequestBody{
 		Count:    max,
-		Requeue:  requeue,
 		Encoding: "auto",
-		Ackmode:  "ack_requeue_true",
+		Ackmode:  ackMode,
 	}
 
 	requestBodyJson, err := json.Marshal(requestBody)


### PR DESCRIPTION
All messages requeue in spite of `requeue` flag because `requeue` field has been removed from Management UI and `ackmode` is `ack_requeue_true`.

> ackmode determines whether the messages will be removed from the queue. If ackmode is ack_requeue_true or reject_requeue_true they will be requeued - if ackmode is ack_requeue_false or reject_requeue_false they will be removed.